### PR TITLE
feat: implement Policy as Code for docker

### DIFF
--- a/.github/workflows/quality-and-security.yml
+++ b/.github/workflows/quality-and-security.yml
@@ -64,6 +64,18 @@ jobs:
             - name: Run govulncheck
               run: |
                   "$(go env GOPATH)/bin/govulncheck" ./...
+    policy-check:
+        name: Policy as Code (Conftest)
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Run Conftest (OPA)
+              uses: instrumenta/conftest-action@master
+              with:
+                files: Dockerfile
+                policy: policy/
 
     build:
         name: Production Build Validation

--- a/.github/workflows/secret_scanning.yml
+++ b/.github/workflows/secret_scanning.yml
@@ -1,0 +1,20 @@
+name: Secret Detection
+
+on: [push, pull_request]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Install Gitleaks
+        run: |
+          wget https://github.com/gitleaks/gitleaks/releases/download/v8.18.4/gitleaks_8.18.4_linux_x64.tar.gz
+          tar -xzf gitleaks_8.18.4_linux_x64.tar.gz
+          sudo mv gitleaks /usr/local/bin/
+          
+      - name: Run Gitleaks
+        run: gitleaks detect --source . -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV CGO_ENABLED=0 \
 RUN go build -o /bin/wacraft-server ./main.go
 
 # 2️⃣ Final lightweight image
-FROM alpine:latest
+FROM alpine:3.22
 
 # Set working directory inside the container
 WORKDIR /root/

--- a/policy/docker.rego
+++ b/policy/docker.rego
@@ -1,0 +1,20 @@
+package main
+
+# prohibiting latest as base image
+deny[msg] {
+  input[i].Cmd == "from"
+  val := split(input[i].Value[0], ":")
+  count(val) > 1
+  val[1] == "latest"
+  msg = sprintf("Não use a tag 'latest' na imagem base: %s", [input[i].Value[0]])
+}
+
+# shouldn´t run as root
+warn[msg] {
+  not has_user_instruction
+  msg = "O Dockerfile deve especificar um 'USER' para não rodar como root"
+}
+
+has_user_instruction {
+  input[i].Cmd == "user"
+}


### PR DESCRIPTION
This PR introduces Policy as Code to the pipeline using Conftest (Open Policy Agent). It adds a governance layer that automatically validates the Dockerfile against security best practices before the build stage.