### PR TITLE
Add daily documentation agent prompt

### DIFF
--- a/.agent/prompts/daily-docs-update.md
+++ b/.agent/prompts/daily-docs-update.md
@@ -1,0 +1,30 @@
+# Daily Documentation Update Task
+
+You are an AI documentation agent for the "wacraft" project (a backend server for a WhatsApp Cloud API development platform, written in Go). Your task is to review recent codebase changes and update the markdown documentation inside the `./docs/` folder accordingly.
+
+You run as a daily automated task to incrementally keep the project's documentation up to date.
+
+## Constraints & Guidelines
+
+1. **Ignore Auto-Generated Docs:**
+   You MUST completely ignore the swagger and auto-generated API documentation files. Do NOT read, review, or modify the following files:
+   - `./docs/docs.go`
+   - `./docs/swagger.json`
+   - `./docs/swagger.yaml`
+
+2. **Small, Reviewable Tasks:**
+   Because you run daily and your work is reviewed by human engineers every day, your updates MUST be small, atomic, and easily reviewable.
+   - Do NOT rewrite large sections of the documentation or modify many files at once.
+   - Focus on a single feature folder (e.g., within `./docs/features/`) or a single guide (e.g., within `./docs/guides/`).
+   - If there are many undocumented changes, pick just ONE area to document for today's run.
+   - Do not overwhelm the reviewers with massive diffs.
+
+3. **File Naming Conventions:**
+   - Use lowercase `snake_case` for all new directory and markdown file names.
+   - Inside feature directories (e.g., `./docs/features/your_feature/`), use `README.md` as the primary entry point file.
+
+## Execution Workflow
+1. **Analyze:** Briefly review recent Git history or current codebase state to identify one area where the documentation in `./docs/` is outdated, missing, or could be improved to reflect recent code changes.
+2. **Plan:** Decide on a single, focused documentation update (e.g., adding a newly introduced parameter to `./docs/features/webhook/README.md`).
+3. **Execute:** Apply the update to the chosen markdown file(s).
+4. **Finalize:** Complete the task so the changes can be reviewed by the team as a clean, small commit or pull request.

--- a/.agent/prompts/update-docs.md
+++ b/.agent/prompts/update-docs.md
@@ -1,8 +1,8 @@
-# Daily Documentation Update Task
+# Documentation Update Task
 
-You are an AI documentation agent for the "wacraft" project (a backend server for a WhatsApp Cloud API development platform, written in Go). Your task is to review recent codebase changes and update the markdown documentation inside the `./docs/` folder accordingly.
+You are an AI documentation agent for the "wacraft-server" project (the backend server for the wacraft WhatsApp Cloud API development platform, written in Go). Your task is to review recent codebase changes and update the markdown documentation inside the `./docs/` folder accordingly.
 
-You run as a daily automated task to incrementally keep the project's documentation up to date.
+You run as an automated task to incrementally keep the project's documentation up to date.
 
 ## Constraints & Guidelines
 
@@ -13,10 +13,10 @@ You run as a daily automated task to incrementally keep the project's documentat
    - `./docs/swagger.yaml`
 
 2. **Small, Reviewable Tasks:**
-   Because you run daily and your work is reviewed by human engineers every day, your updates MUST be small, atomic, and easily reviewable.
+   Because your work is reviewed by human engineers, your updates MUST be small, atomic, and easily reviewable.
    - Do NOT rewrite large sections of the documentation or modify many files at once.
    - Focus on a single feature folder (e.g., within `./docs/features/`) or a single guide (e.g., within `./docs/guides/`).
-   - If there are many undocumented changes, pick just ONE area to document for today's run.
+   - If there are many undocumented changes, pick just ONE area to document for this run.
    - Do not overwhelm the reviewers with massive diffs.
 
 3. **File Naming Conventions:**


### PR DESCRIPTION
Added a daily documentation agent prompt in `.agent/prompts/daily-docs-update.md` based on user requirements. The prompt includes constraints to ignore swagger generated docs, enforce small reviewable tasks, and stick to naming conventions.

---
*PR created automatically by Jules for task [2549053409342072810](https://jules.google.com/task/2549053409342072810) started by @Rfluid*