### PR TITLE
Add daily agent workspace update prompt

### DIFF
--- a/.agent/prompts/update-agent-workspace.md
+++ b/.agent/prompts/update-agent-workspace.md
@@ -1,12 +1,12 @@
 # Update Agent Workspace
 
-Review the current repository state and update the `.agent/` workspace to reflect new patterns, fix drift, or improve agent workflows.
+You are an agent responsible for maintaining and improving the `.agent/` workspace. Your goal is to review the current repository state and update the workspace to reflect new patterns, fix drift, or improve workflows for future agent operations.
 
-This task runs daily. Updates must be small, focused, and easily reviewable.
+Updates must be small, focused, and easily reviewable.
 
 Requirements:
 
-- Identify **one** specific area for improvement (e.g., adding a new skill, updating an outdated prompt, or refining core conventions).
+- Identify **one** specific area for improvement per execution (e.g., adding a new skill, updating an outdated prompt, or refining core conventions).
 - Keep changes localized and minimal. Human review should take less than 5 minutes.
 - Do not make sweeping changes across multiple files or directories in the `.agent/` workspace in a single run.
 - Do not alter repository source code (`./src`) or feature documentation (`./docs`) during this task.

--- a/.agent/prompts/update-agent-workspace.md
+++ b/.agent/prompts/update-agent-workspace.md
@@ -1,0 +1,26 @@
+# Update Agent Workspace
+
+Review the current repository state and update the `.agent/` workspace to reflect new patterns, fix drift, or improve agent workflows.
+
+This task runs daily. Updates must be small, focused, and easily reviewable.
+
+Requirements:
+
+- Identify **one** specific area for improvement (e.g., adding a new skill, updating an outdated prompt, or refining core conventions).
+- Keep changes localized and minimal. Human review should take less than 5 minutes.
+- Do not make sweeping changes across multiple files or directories in the `.agent/` workspace in a single run.
+- Do not alter repository source code (`./src`) or feature documentation (`./docs`) during this task.
+- Base your updates on recent codebase changes, observed patterns, or missing instructions.
+
+Focus questions:
+
+- Has a new architectural pattern emerged that needs to be documented in `core/`?
+- Are there repetitive tasks that could benefit from a new template in `skills/`?
+- Are any existing prompts in `prompts/` returning suboptimal results or missing context?
+- Do any helper scripts in `tools/` need maintenance?
+
+Expected output:
+
+1. A short explanation of the targeted change and its motivation.
+2. Concrete file additions or modifications within `.agent/`.
+3. A brief note on how this change improves future agent operations.


### PR DESCRIPTION
Adds a new prompt `.agent/prompts/update-agent-workspace.md` that directs an agent to review the repository state and safely update the `.agent/` workspace. The prompt specifically instructs the agent to make small, reviewable changes focused on one specific area per daily run, while preventing sweeping edits and modifications outside the `.agent/` scope.

---
*PR created automatically by Jules for task [9907744952245587370](https://jules.google.com/task/9907744952245587370) started by @Rfluid*