### PR TITLE
docs: Update multi_tenant implementation summary with OptionalWorkspaceMiddleware

### DIFF
--- a/docs/features/multi_tenant/implementation_summary.md
+++ b/docs/features/multi_tenant/implementation_summary.md
@@ -64,10 +64,11 @@ Added `WorkspaceID *uuid.UUID` to:
 
 ### Middleware
 
-| File                                    | Purpose                                                |
-| --------------------------------------- | ------------------------------------------------------ |
-| `src/workspace/middleware/workspace.go` | Extracts `X-Workspace-ID` header, validates membership |
-| `src/workspace/middleware/policy.go`    | `RequirePolicy()` - Checks user has required policies  |
+| File                                    | Purpose                                                                             |
+| --------------------------------------- | ----------------------------------------------------------------------------------- |
+| `src/workspace/middleware/workspace.go` | `WorkspaceMiddleware` - Extracts `X-Workspace-ID` header, validates membership      |
+| `src/workspace/middleware/workspace.go` | `OptionalWorkspaceMiddleware` - Same as above, but skips silently if ID not present |
+| `src/workspace/middleware/policy.go`    | `RequirePolicy()` - Checks user has required policies                               |
 
 ### API Endpoints
 


### PR DESCRIPTION
Add the `OptionalWorkspaceMiddleware` to the "Middleware" table in `docs/features/multi_tenant/implementation_summary.md`, explicitly differentiating it from the standard `WorkspaceMiddleware`.

This is a focused documentation update to keep feature implementation summaries aligned with the actual codebase.

---
*PR created automatically by Jules for task [7319028595945968445](https://jules.google.com/task/7319028595945968445) started by @Rfluid*