### PR TITLE
chore(agent): update CONVENTIONS.md to forbid temp main packages and add test flags

### DIFF
--- a/.agent/core/CONVENTIONS.md
+++ b/.agent/core/CONVENTIONS.md
@@ -11,6 +11,7 @@ These conventions are specific to this repository and should guide agent work.
 5. Treat workspace scoping and auth middleware as security boundaries, not convenience layers.
 6. Update migrations intentionally when persistence shape changes; do not rely on implicit auto-migration behavior alone.
 7. Keep memory and Redis sync modes behaviorally aligned unless a task explicitly targets one backend.
+8. Do not leave temporary `.go` files containing `main` packages or functions in the repository, as they cause GitHub CI (CodeQL SAST scans and builds) to fail.
 
 ## Repo Design Bias
 
@@ -51,7 +52,7 @@ For most tasks:
 At minimum, changes should include:
 
 - focused package tests for the changed behavior when practical
-- `go test ./... -v` for normal regression coverage
+- `go test ./... -v -p 1` for normal regression coverage (use `-p 1` to execute packages sequentially, preventing race conditions and unique constraint violations caused by concurrent GORM `AutoMigrate` calls)
 - `make test-memory` or `make test-distributed` when sync, database, websocket, or worker behavior changes
 - an explicit note of any verification gap when external dependencies make full validation impractical
 


### PR DESCRIPTION
Updated `.agent/core/CONVENTIONS.md` to:
- Explicitly forbid leaving temporary `.go` files with `main` packages/functions, as they cause GitHub CI (CodeQL SAST scans and builds) to fail.
- Update `Testing Expectations` to specify the use of the `-p 1` flag for `go test ./...` to prevent race conditions and unique constraint violations during concurrent GORM `AutoMigrate` calls across multiple packages.

These additions to the core conventions provide essential workflow instructions to avoid breaking the CI pipeline or local testing for agents operating on the codebase in the future.

---
*PR created automatically by Jules for task [7141482514099795986](https://jules.google.com/task/7141482514099795986) started by @Rfluid*