### PR TITLE
⚡ Bolt: Fix N+1 queries using GORM batch insertions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -22,3 +22,8 @@
 
 **Learning:** Identified an N+1 query issue during the creation of workspace member policies (e.g., in `AddMember`, `UpdateMemberPolicies`, workspace `Create`, and user `Register` handlers). The previous implementation used a loop over `workspace_model.AllPolicies` or user-defined policies to execute a `repository.Create` or `tx.Create` for each individual `WorkspaceMemberPolicy` record. In GORM, this incurs a database roundtrip and transaction overhead per policy.
 **Action:** When inserting multiple rows of the same type, prepare a slice of the entities and use `tx.Create(&slice)` for batch insertion. This minimizes lock contention, lowers transaction overhead, and improves overall application performance during creation routines.
+
+## 2026-04-16 - Fixed N+1 Query in Plan Pricing and Workspace Invitation Policies
+
+**Learning:** Found an N+1 query issue in the `CreatePlan` handler (`src/billing/handler/plan.go`) and the `AcceptInvitation` handler (`src/workspace/handler/invitation.go`). The previous implementation used a loop over user-provided arrays to execute `tx.Create()` for each individual record (e.g. `billing_entity.PlanPrice` and `workspace_entity.WorkspaceMemberPolicy`). This incurs a database roundtrip and transaction overhead per iteration.
+**Action:** When inserting multiple rows of the same type via GORM, prepare a slice of the entities and use `tx.Create(&slice)` for batch insertion to eliminate N+1 overhead during database operations.

--- a/src/billing/handler/plan.go
+++ b/src/billing/handler/plan.go
@@ -102,13 +102,19 @@ func CreatePlan(c *fiber.Ctx) error {
 			return err
 		}
 
-		for _, p := range body.Prices {
-			if err := tx.Create(&billing_entity.PlanPrice{
-				PlanID:     result.ID,
-				Currency:   p.Currency,
-				PriceCents: p.PriceCents,
-				IsDefault:  p.IsDefault,
-			}).Error; err != nil {
+		// ⚡ Bolt: Optimize by using batch insertion instead of creating each price individually in a loop
+		if len(body.Prices) > 0 {
+			pricesToInsert := make([]billing_entity.PlanPrice, 0, len(body.Prices))
+			for _, p := range body.Prices {
+				pricesToInsert = append(pricesToInsert, billing_entity.PlanPrice{
+					PlanID:     result.ID,
+					Currency:   p.Currency,
+					PriceCents: p.PriceCents,
+					IsDefault:  p.IsDefault,
+				})
+			}
+
+			if err := tx.Create(&pricesToInsert).Error; err != nil {
 				return err
 			}
 		}

--- a/src/workspace/handler/invitation.go
+++ b/src/workspace/handler/invitation.go
@@ -284,12 +284,17 @@ func ClaimInvitation(c *fiber.Ctx) error {
 	}
 
 	// Assign policies from invitation
-	for _, policy := range invitation.Policies {
-		policyRecord := workspace_entity.WorkspaceMemberPolicy{
-			WorkspaceMemberID: member.ID,
-			Policy:            policy,
+	// ⚡ Bolt: Optimize by using batch insertion instead of creating each policy record individually in a loop
+	if len(invitation.Policies) > 0 {
+		policiesToInsert := make([]workspace_entity.WorkspaceMemberPolicy, 0, len(invitation.Policies))
+		for _, policy := range invitation.Policies {
+			policiesToInsert = append(policiesToInsert, workspace_entity.WorkspaceMemberPolicy{
+				WorkspaceMemberID: member.ID,
+				Policy:            policy,
+			})
 		}
-		if err := tx.Create(&policyRecord).Error; err != nil {
+
+		if err := tx.Create(&policiesToInsert).Error; err != nil {
 			tx.Rollback()
 			return c.Status(fiber.StatusInternalServerError).JSON(
 				common_model.NewApiError("Failed to assign policies", err, "database").Send(),


### PR DESCRIPTION
💡 What: Replaced individual `tx.Create` operations inside loops with single batch insertions for `PlanPrice` records in `src/billing/handler/plan.go` and `WorkspaceMemberPolicy` records in `src/workspace/handler/invitation.go`.

🎯 Why: During creation flows (creating a plan or accepting an invitation), looping over arrays and performing individual inserts causes N+1 database roundtrips.

📊 Impact: Reduces database transaction overhead and minimizes round-trips from O(n) to O(1) for associated price and policy record insertions, tangibly improving handler execution time.

🔬 Measurement: Check the number of `INSERT INTO` statements emitted in DB debug logs when creating a billing plan with multiple prices or accepting an invitation with multiple policies.

---
*PR created automatically by Jules for task [17542054639774641274](https://jules.google.com/task/17542054639774641274) started by @Rfluid*