### PR TITLE
⚡ Bolt: [Performance] Batch insertions for N+1 queries in plan and workspace handlers

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -22,3 +22,7 @@
 
 **Learning:** Identified an N+1 query issue during the creation of workspace member policies (e.g., in `AddMember`, `UpdateMemberPolicies`, workspace `Create`, and user `Register` handlers). The previous implementation used a loop over `workspace_model.AllPolicies` or user-defined policies to execute a `repository.Create` or `tx.Create` for each individual `WorkspaceMemberPolicy` record. In GORM, this incurs a database roundtrip and transaction overhead per policy.
 **Action:** When inserting multiple rows of the same type, prepare a slice of the entities and use `tx.Create(&slice)` for batch insertion. This minimizes lock contention, lowers transaction overhead, and improves overall application performance during creation routines.
+
+## 2024-10-24 - Batch Insert for Relationship Data in Handlers
+**Learning:** In GORM, iterating through an array from an API request to perform single inserts (`tx.Create(&struct)`) inside a transaction can quietly create an N+1 query issue for relationship data (e.g., `PlanPrice` array for `Plan`, `WorkspaceMemberPolicy` array for `WorkspaceMember`). While these are fast locally, they cause multiple DB round trips and transaction locking overhead.
+**Action:** When handling arrays of incoming nested data in handlers, map the incoming payload into a slice of entity structs, then use GORM's batch insert capabilities (`tx.Create(&slice)`) to combine all inserts into a single `INSERT` statement.

--- a/src/billing/handler/plan.go
+++ b/src/billing/handler/plan.go
@@ -102,13 +102,19 @@ func CreatePlan(c *fiber.Ctx) error {
 			return err
 		}
 
-		for _, p := range body.Prices {
-			if err := tx.Create(&billing_entity.PlanPrice{
-				PlanID:     result.ID,
-				Currency:   p.Currency,
-				PriceCents: p.PriceCents,
-				IsDefault:  p.IsDefault,
-			}).Error; err != nil {
+		// ⚡ BOLT OPTIMIZATION: Use batch insert to prevent N+1 queries when creating multiple prices
+		if len(body.Prices) > 0 {
+			pricesToInsert := make([]billing_entity.PlanPrice, 0, len(body.Prices))
+			for _, p := range body.Prices {
+				pricesToInsert = append(pricesToInsert, billing_entity.PlanPrice{
+					PlanID:     result.ID,
+					Currency:   p.Currency,
+					PriceCents: p.PriceCents,
+					IsDefault:  p.IsDefault,
+				})
+			}
+
+			if err := tx.Create(&pricesToInsert).Error; err != nil {
 				return err
 			}
 		}

--- a/src/workspace/handler/invitation.go
+++ b/src/workspace/handler/invitation.go
@@ -284,12 +284,17 @@ func ClaimInvitation(c *fiber.Ctx) error {
 	}
 
 	// Assign policies from invitation
-	for _, policy := range invitation.Policies {
-		policyRecord := workspace_entity.WorkspaceMemberPolicy{
-			WorkspaceMemberID: member.ID,
-			Policy:            policy,
+	// ⚡ BOLT OPTIMIZATION: Use batch insert to prevent N+1 queries when assigning multiple policies
+	if len(invitation.Policies) > 0 {
+		policiesToInsert := make([]workspace_entity.WorkspaceMemberPolicy, 0, len(invitation.Policies))
+		for _, policy := range invitation.Policies {
+			policiesToInsert = append(policiesToInsert, workspace_entity.WorkspaceMemberPolicy{
+				WorkspaceMemberID: member.ID,
+				Policy:            policy,
+			})
 		}
-		if err := tx.Create(&policyRecord).Error; err != nil {
+
+		if err := tx.Create(&policiesToInsert).Error; err != nil {
 			tx.Rollback()
 			return c.Status(fiber.StatusInternalServerError).JSON(
 				common_model.NewApiError("Failed to assign policies", err, "database").Send(),


### PR DESCRIPTION
💡 **What**: Refactored the `CreatePlan` and `ClaimInvitation` handlers to use GORM's batch insertion feature (`tx.Create(&slice)`). The request payloads are mapped to slices in memory before execution, replacing loops calling individual `tx.Create(&struct)` statements.

🎯 **Why**: Executing individual insert statements for each nested relationship entity within a loop (e.g. `PlanPrice`, `WorkspaceMemberPolicy`) creates an N+1 query pattern. Each insertion executes a separate database query, causing unnecessary database roundtrips and transaction lock contention.

📊 **Impact**: Reduces database queries from 1+N inserts to just 2 inserts (one for the parent entity, one batch insert for all child entities). This optimizes memory and processing time under high traffic.

🔬 **Measurement**: Verify by benchmarking the creation handlers locally. Code functionality remains unchanged, as validated by test execution.

---
*PR created automatically by Jules for task [17260792292379311331](https://jules.google.com/task/17260792292379311331) started by @Rfluid*