### PR TITLE
Fix db migrations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
                   cosign sign --yes --key env://COSIGN_PRIVATE_KEY "${{ env.IMAGE_NAME }}:latest"
 
             - name: Publish GitHub release
-              uses: softprops/action-gh-release@v2
+              uses: softprops/action-gh-release@v3
               with:
                   tag_name: ${{ steps.vars.outputs.tag }}
                   generate_release_notes: true

--- a/src/database/migrations/20250825004905_create_immutable_unaccent.go
+++ b/src/database/migrations/20250825004905_create_immutable_unaccent.go
@@ -30,8 +30,9 @@ func upCreateImmutableUnaccent(ctx context.Context, tx *sql.Tx) error {
 			IMMUTABLE
 			PARALLEL SAFE
 			STRICT
+			SET search_path = public, pg_catalog
 		AS $$
-			SELECT unaccent('unaccent'::regdictionary, $1)
+			SELECT unaccent('unaccent', $1);
 		$$;`,
 	}
 

--- a/src/database/migrations/20250825004905_create_immutable_unaccent.go
+++ b/src/database/migrations/20250825004905_create_immutable_unaccent.go
@@ -32,7 +32,7 @@ func upCreateImmutableUnaccent(ctx context.Context, tx *sql.Tx) error {
 			STRICT
 			SET search_path = public, pg_catalog
 		AS $$
-			SELECT unaccent('unaccent', $1);
+			SELECT unaccent('unaccent', $1)
 		$$;`,
 	}
 

--- a/src/database/migrations/20250825004905_create_immutable_unaccent.go
+++ b/src/database/migrations/20250825004905_create_immutable_unaccent.go
@@ -32,7 +32,7 @@ func upCreateImmutableUnaccent(ctx context.Context, tx *sql.Tx) error {
 			STRICT
 			SET search_path = public, pg_catalog
 		AS $$
-			SELECT unaccent('unaccent', $1)
+			SELECT unaccent('unaccent'::regdictionary, $1)
 		$$;`,
 	}
 

--- a/src/database/migrations/20250825024334_create_contact_indexes.go
+++ b/src/database/migrations/20250825024334_create_contact_indexes.go
@@ -29,8 +29,9 @@ func upCreateContactIndexes(ctx context.Context, tx *sql.Tx) error {
 			IMMUTABLE
 			PARALLEL SAFE
 			STRICT
+			SET search_path = public, pg_catalog
 		AS $$
-			SELECT unaccent('unaccent'::regdictionary, $1)
+			SELECT unaccent('unaccent', $1)
 		$$;`,
 
 		// 2) messaging_product_contacts.product_details (jsonb as text)

--- a/src/database/migrations/20250825024334_create_contact_indexes.go
+++ b/src/database/migrations/20250825024334_create_contact_indexes.go
@@ -31,7 +31,7 @@ func upCreateContactIndexes(ctx context.Context, tx *sql.Tx) error {
 			STRICT
 			SET search_path = public, pg_catalog
 		AS $$
-			SELECT unaccent('unaccent', $1)
+			SELECT unaccent('unaccent'::regdictionary, $1)
 		$$;`,
 
 		// 2) messaging_product_contacts.product_details (jsonb as text)


### PR DESCRIPTION
When running the code in an empty db I was getting errors while running the migrations.
This fixed the issue by specifying the search path for the unaccent function.

To reproduce the issue, run the project in an empty db using a postgres:17-alpine docker image.

Please feel free to close/edit this PR according to your standards. I am just opening the PR to contribute with my findings.