### PR TITLE
⚡ Bolt: [performance improvement] Batch workspace policy assignment in invitations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -22,3 +22,7 @@
 
 **Learning:** Identified an N+1 query issue during the creation of workspace member policies (e.g., in `AddMember`, `UpdateMemberPolicies`, workspace `Create`, and user `Register` handlers). The previous implementation used a loop over `workspace_model.AllPolicies` or user-defined policies to execute a `repository.Create` or `tx.Create` for each individual `WorkspaceMemberPolicy` record. In GORM, this incurs a database roundtrip and transaction overhead per policy.
 **Action:** When inserting multiple rows of the same type, prepare a slice of the entities and use `tx.Create(&slice)` for batch insertion. This minimizes lock contention, lowers transaction overhead, and improves overall application performance during creation routines.
+
+## 2026-04-18 - Fixed N+1 Query in Workspace Invitation Claiming
+**Learning:** Found another instance of the N+1 query pattern during the creation of workspace member policies in the `ClaimInvitation` handler (`src/workspace/handler/invitation.go`). The previous implementation looped over `invitation.Policies` and inserted them individually, which adds transaction overhead and database roundtrips per policy.
+**Action:** Used `make()` to allocate a slice with a predefined capacity, appended the individual records inside the loop, and replaced the individual `tx.Create` with a single batch `tx.Create(&policiesToInsert)`. This follows the same optimization applied previously to other workspace onboarding endpoints.

--- a/src/workspace/handler/invitation.go
+++ b/src/workspace/handler/invitation.go
@@ -283,16 +283,20 @@ func ClaimInvitation(c *fiber.Ctx) error {
 		)
 	}
 
-	// Assign policies from invitation
-	for _, policy := range invitation.Policies {
-		policyRecord := workspace_entity.WorkspaceMemberPolicy{
-			WorkspaceMemberID: member.ID,
-			Policy:            policy,
+	// Assign policies from invitation in batch
+	if len(invitation.Policies) > 0 {
+		policiesToInsert := make([]workspace_entity.WorkspaceMemberPolicy, 0, len(invitation.Policies))
+		for _, policy := range invitation.Policies {
+			policiesToInsert = append(policiesToInsert, workspace_entity.WorkspaceMemberPolicy{
+				WorkspaceMemberID: member.ID,
+				Policy:            policy,
+			})
 		}
-		if err := tx.Create(&policyRecord).Error; err != nil {
+
+		if err := tx.Create(&policiesToInsert).Error; err != nil {
 			tx.Rollback()
 			return c.Status(fiber.StatusInternalServerError).JSON(
-				common_model.NewApiError("Failed to assign policies", err, "database").Send(),
+				common_model.NewApiError("Failed to assign policies in batch", err, "database").Send(),
 			)
 		}
 	}


### PR DESCRIPTION
💡 **What**: Replaced the iterative `tx.Create` loop for workspace member policies with a single, batched slice insert in `ClaimInvitation`.
🎯 **Why**: Executing queries in a `for` loop produces an N+1 query scenario, slowing down endpoint responsiveness when assigning multiple policies by incurring multiple roundtrips and compounding transaction overhead.
📊 **Impact**: Reduces database insert statements from O(N) to O(1) for policy assignment when a user claims an invitation. Lower database load and lock contention.
🔬 **Measurement**: Execute `go test ./src/workspace/... -p 1 -short` to verify functionality. Check the PostgreSQL query logs if enabled during invitation processing; there should be a single `INSERT` for policies rather than `len(invitation.Policies)` inserts.

---
*PR created automatically by Jules for task [9148982682738183835](https://jules.google.com/task/9148982682738183835) started by @Rfluid*