### PR TITLE
⚡ Bolt: Batch insert messages and fix unsafe concurrent transaction usage in webhooks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -22,3 +22,8 @@
 
 **Learning:** Identified an N+1 query issue during the creation of workspace member policies (e.g., in `AddMember`, `UpdateMemberPolicies`, workspace `Create`, and user `Register` handlers). The previous implementation used a loop over `workspace_model.AllPolicies` or user-defined policies to execute a `repository.Create` or `tx.Create` for each individual `WorkspaceMemberPolicy` record. In GORM, this incurs a database roundtrip and transaction overhead per policy.
 **Action:** When inserting multiple rows of the same type, prepare a slice of the entities and use `tx.Create(&slice)` for batch insertion. This minimizes lock contention, lowers transaction overhead, and improves overall application performance during creation routines.
+
+## 2026-04-21 - Fixed GORM Concurrent Transaction and N+1 Inserts in Webhook Handlers
+
+**Learning:** Passing a single `tx *gorm.DB` transaction object into concurrent goroutines (e.g., inside an `errgroup`) is unsafe and leads to race conditions, as a single transaction uses exactly one connection that is not thread-safe for concurrent queries. Furthermore, creating rows individually within a loop causes unnecessary database round-trips (N+1 query pattern for inserts).
+**Action:** Always execute transaction-bound operations sequentially. To optimize multiple inserts, accumulate the entities into a slice during a sequential loop and use `tx.Create(&slice)` for a single batch insert.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -26,3 +26,8 @@
 
 **Learning:** When using GORM to perform a "get-or-save" (upsert-like) operation, a common anti-pattern is to create a core entity, create a related entity using the core's ID, and then immediately execute a `.Preload("RelationName").First(&entity)` database query just to return the fully populated object. This forces an unnecessary SELECT query right after the INSERTs.
 **Action:** When creating related objects within a single function scope where the relation's data is already in memory, simply assign the pointer of the existing object directly to the relationship struct field (e.g., `mpContact.Contact = &contact`) before returning. This completely eliminates the subsequent database round-trip required by `.Preload()`.
+
+## 2026-04-21 - Fixed GORM Concurrent Transaction and N+1 Inserts in Webhook Handlers
+
+**Learning:** Passing a single `tx *gorm.DB` transaction object into concurrent goroutines (e.g., inside an `errgroup`) is unsafe and leads to race conditions, as a single transaction uses exactly one connection that is not thread-safe for concurrent queries. Furthermore, creating rows individually within a loop causes unnecessary database round-trips (N+1 query pattern for inserts).
+**Action:** Always execute transaction-bound operations sequentially. To optimize multiple inserts, accumulate the entities into a slice during a sequential loop and use `tx.Create(&slice)` for a single batch insert.

--- a/src/webhook-in/handler/whatsapp-message.go
+++ b/src/webhook-in/handler/whatsapp-message.go
@@ -2,7 +2,6 @@ package webhook_handler
 
 import (
 	"fmt"
-	"sync"
 
 	contact_entity "github.com/Astervia/wacraft-core/src/contact/entity"
 	message_entity "github.com/Astervia/wacraft-core/src/message/entity"
@@ -249,139 +248,127 @@ func messageCallback(ctx *fiber.Ctx, body *wh_model.WebhookBody, change *wh_mode
 // handleMessagesWithWorkspace handles messages with workspace context.
 // Contacts created through this handler will be associated with the workspace.
 func handleMessagesWithWorkspace(value wh_model.Value, tx *gorm.DB, mpID uuid.UUID, workspaceID *uuid.UUID) ([]message_entity.Message, error) {
-	var eg errgroup.Group
-
 	msgs := []message_entity.Message{}
-	var msgsMu sync.Mutex
 
-	// Handling each message
+	// Handling each message sequentially to safely use the transaction and batch inserts
 	for index, message := range *value.Messages {
-		eg.Go(func() error {
-			// Interpolating message properties
-			var name string
-			if value.Contacts != nil && len(*value.Contacts) >= index {
-				name = (*value.Contacts)[index].Profile.Name
-			}
+		// Interpolating message properties
+		var name string
+		if value.Contacts != nil && len(*value.Contacts) >= index {
+			name = (*value.Contacts)[index].Profile.Name
+		}
 
-			mpContact, err := messaging_product_service.GetContactOrSave(
-				messaging_product_entity.MessagingProductContact{
-					MessagingProductID: mpID,
-					ProductDetails: &messaging_product_model.ProductDetails{
-						WhatsAppProductDetails: &messaging_product_model.WhatsAppProductDetails{
-							WaID:        message.From,
-							PhoneNumber: message.From,
-						},
+		mpContact, err := messaging_product_service.GetContactOrSave(
+			messaging_product_entity.MessagingProductContact{
+				MessagingProductID: mpID,
+				ProductDetails: &messaging_product_model.ProductDetails{
+					WhatsAppProductDetails: &messaging_product_model.WhatsAppProductDetails{
+						WaID:        message.From,
+						PhoneNumber: message.From,
 					},
 				},
-				contact_entity.Contact{
-					Name:        &name,
-					Email:       nil,
-					WorkspaceID: workspaceID,
-				},
-				tx,
-			)
-			if err != nil {
-				return err
-			}
-
-			// Building the message entity and creating with the mp contact found
-			msg := message_entity.Message{
-				MessageFields: message_model.MessageFields{
-					ReceiverData:       &message_model.ReceiverData{MessageReceived: &message},
-					FromID:             &mpContact.ID,
-					MessagingProductID: mpID,
-				},
-				From: &mpContact,
-			}
-			if msg.From.Blocked {
-				return nil
-			}
-			err = tx.Model(&msg).Create(&msg).Error
-			if err != nil {
-				return err
-			}
-			msgsMu.Lock()
-			msgs = append(msgs, msg)
-			msgsMu.Unlock()
-			return nil
-		})
-	}
-
-	err := eg.Wait()
-	if err != nil {
-		pterm.DefaultLogger.Error(
-			fmt.Sprintf("Error while handling message with workspace: %s", err.Error()),
+			},
+			contact_entity.Contact{
+				Name:        &name,
+				Email:       nil,
+				WorkspaceID: workspaceID,
+			},
+			tx,
 		)
+		if err != nil {
+			pterm.DefaultLogger.Error(
+				fmt.Sprintf("Error while getting or saving contact with workspace: %s", err.Error()),
+			)
+			return nil, err
+		}
+
+		// Building the message entity
+		msg := message_entity.Message{
+			MessageFields: message_model.MessageFields{
+				ReceiverData:       &message_model.ReceiverData{MessageReceived: &message},
+				FromID:             &mpContact.ID,
+				MessagingProductID: mpID,
+			},
+			From: &mpContact,
+		}
+		if msg.From.Blocked {
+			continue
+		}
+		msgs = append(msgs, msg)
 	}
 
-	return msgs, err
+	// Batch insert all unblocked messages
+	if len(msgs) > 0 {
+		if err := tx.Create(&msgs).Error; err != nil {
+			pterm.DefaultLogger.Error(
+				fmt.Sprintf("Error while creating messages with workspace: %s", err.Error()),
+			)
+			return nil, err
+		}
+	}
+
+	return msgs, nil
 }
 
 // Returns messages from unblocked contacts (legacy handler without workspace context)
 func handleMessages(value wh_model.Value, tx *gorm.DB, mpID uuid.UUID) ([]message_entity.Message, error) {
-	var eg errgroup.Group
-
 	msgs := []message_entity.Message{}
-	var msgsMu sync.Mutex
 
-	// Handling each message
+	// Handling each message sequentially to safely use the transaction and batch inserts
 	for index, message := range *value.Messages {
-		eg.Go(func() error {
-			// Interpolating message properties
-			var name string
-			if value.Contacts != nil && len(*value.Contacts) >= index {
-				name = (*value.Contacts)[index].Profile.Name
-			}
+		// Interpolating message properties
+		var name string
+		if value.Contacts != nil && len(*value.Contacts) >= index {
+			name = (*value.Contacts)[index].Profile.Name
+		}
 
-			mpContact, err := messaging_product_service.GetContactOrSave(
-				messaging_product_entity.MessagingProductContact{
-					MessagingProductID: mpID,
-					ProductDetails: &messaging_product_model.ProductDetails{
-						WhatsAppProductDetails: &messaging_product_model.WhatsAppProductDetails{
-							WaID:        message.From,
-							PhoneNumber: message.From,
-						},
+		mpContact, err := messaging_product_service.GetContactOrSave(
+			messaging_product_entity.MessagingProductContact{
+				MessagingProductID: mpID,
+				ProductDetails: &messaging_product_model.ProductDetails{
+					WhatsAppProductDetails: &messaging_product_model.WhatsAppProductDetails{
+						WaID:        message.From,
+						PhoneNumber: message.From,
 					},
 				},
-				contact_entity.Contact{
-					Name:  &name,
-					Email: nil,
-				},
-				tx,
-			)
-			if err != nil {
-				return err
-			}
-
-			// Building the message entity and creating with the mp contact found
-			msg := message_entity.Message{
-				MessageFields: message_model.MessageFields{
-					ReceiverData:       &message_model.ReceiverData{MessageReceived: &message},
-					FromID:             &mpContact.ID,
-					MessagingProductID: mpID,
-				},
-				From: &mpContact,
-			}
-			if msg.From.Blocked {
-				return nil
-			}
-			err = tx.Model(&msg).Create(&msg).Error
-			if err != nil {
-				return err
-			}
-			msgsMu.Lock()
-			msgs = append(msgs, msg)
-			msgsMu.Unlock()
-			return nil
-		})
-	}
-
-	err := eg.Wait()
-	if err != nil {
-		pterm.DefaultLogger.Error(
-			fmt.Sprintf("Error while handling message: %s", err.Error()),
+			},
+			contact_entity.Contact{
+				Name:  &name,
+				Email: nil,
+			},
+			tx,
 		)
+		if err != nil {
+			pterm.DefaultLogger.Error(
+				fmt.Sprintf("Error while getting or saving contact: %s", err.Error()),
+			)
+			return nil, err
+		}
+
+		// Building the message entity
+		msg := message_entity.Message{
+			MessageFields: message_model.MessageFields{
+				ReceiverData:       &message_model.ReceiverData{MessageReceived: &message},
+				FromID:             &mpContact.ID,
+				MessagingProductID: mpID,
+			},
+			From: &mpContact,
+		}
+		if msg.From.Blocked {
+			continue
+		}
+		msgs = append(msgs, msg)
 	}
 
-	return msgs, err
+	// Batch insert all unblocked messages
+	if len(msgs) > 0 {
+		if err := tx.Create(&msgs).Error; err != nil {
+			pterm.DefaultLogger.Error(
+				fmt.Sprintf("Error while creating messages: %s", err.Error()),
+			)
+			return nil, err
+		}
+	}
+
+	return msgs, nil
 }


### PR DESCRIPTION
💡 What: Refactored `handleMessagesWithWorkspace` and `handleMessages` to use a sequential loop that gathers message entities into a slice, followed by a single batch insert (`tx.Create(&msgs)`). Removed `errgroup` and the `msgsMu` mutex.
🎯 Why: Previously, the code used an `errgroup` to concurrently insert messages using a shared database transaction (`tx *gorm.DB`). This is not thread-safe in Go and can lead to race conditions or database driver connection errors. Additionally, executing a `tx.Create` for every individual message results in an N+1 query bottleneck during high-volume webhook events.
📊 Impact: Eliminates N+1 database round-trips for message creation, batching them into a single query. Completely removes the risk of transaction connection race conditions during concurrent handler execution.
🔬 Measurement: Verify by sending a batch webhook containing multiple messages and observing the generated SQL trace (single `INSERT INTO` with multiple value tuples) and measuring the reduced latency of the webhook endpoint response time.

---
*PR created automatically by Jules for task [7759162144327461964](https://jules.google.com/task/7759162144327461964) started by @Rfluid*