### PR TITLE
🛡️ Sentinel: [HIGH] Fix integer overflow in exponential backoff delay calculation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-04-24 - [Integer Overflow in Exponential Backoff]
+**Vulnerability:** Integer overflow in exponential backoff delay calculation (`1<<uint(attemptCount)`) leading to zero or incorrect negative-like shifts when attempt count exceeds max bit size.
+**Learning:** Operations involving bit shifting with unconstrained integers from database inputs (like attempt counts) can overflow and cause unintended logic states like zero delay loops.
+**Prevention:** Always bound the shift amount before the shift operation (`if shift > 30 { shift = 30 }`).

--- a/src/webhook/service/queue.go
+++ b/src/webhook/service/queue.go
@@ -181,7 +181,11 @@ func UpdateDeliveryStatus(delivery *webhook_entity.WebhookDelivery, success bool
 		if baseDelay == 0 {
 			baseDelay = 1000 * time.Millisecond
 		}
-		delay := baseDelay * time.Duration(1<<uint(delivery.AttemptCount-1))
+		shift := delivery.AttemptCount - 1
+		if shift > 30 {
+			shift = 30 // Prevent integer overflow
+		}
+		delay := baseDelay * time.Duration(1<<uint(shift))
 		maxDelay := 1 * time.Hour
 		if delay > maxDelay {
 			delay = maxDelay


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Integer overflow in exponential backoff delay calculation where an unbounded `attemptCount` shift could exceed bit size limits, causing the calculated delay to be `0` bypassing `maxDelay` and creating a tight retry loop (DoS risk).
🎯 Impact: This could cause infinite, zero-delay retry loops putting excessive stress on external services and exhausting internal resources.
🔧 Fix: Bounded the maximum bit shift (`attemptCount - 1`) to 30. This safely avoids `int64` and `uint` capacity overflows while easily hitting the 1-hour `maxDelay` threshold limit.
✅ Verification: Ran unit tests via `go test ./...` and statically analyzed changes to verify bounds correctly enforce safe shifting and cap delays.

---
*PR created automatically by Jules for task [13455015042601817001](https://jules.google.com/task/13455015042601817001) started by @Rfluid*