### PR TITLE
🛡️ Sentinel: [HIGH] Fix integer overflow in webhook retry logic

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-25 - Prevent Integer Overflow in Exponential Backoff
+**Vulnerability:** Integer overflow conversion `int -> uint` in webhook retry logic when doing `1<<uint(delivery.AttemptCount-1)` reported by gosec.
+**Learning:** `AttemptCount` can grow infinitely if not constrained properly before bitwise operations, which would cause an integer overflow leading to a 0 multiplier in exponential backoff calculations, causing immediate, zero-delay retries and potentially resulting in denial of service.
+**Prevention:** When implementing exponential backoff or dynamic math using bitwise shifts (`<<`) in Go, explicitly cap the shift limit (e.g., `if shift > 30 { shift = 30 }`) to prevent integer overflows and silent 0 evaluations when unconstrained database inputs exceed maximum bit sizes.

--- a/src/webhook/service/queue.go
+++ b/src/webhook/service/queue.go
@@ -181,7 +181,13 @@ func UpdateDeliveryStatus(delivery *webhook_entity.WebhookDelivery, success bool
 		if baseDelay == 0 {
 			baseDelay = 1000 * time.Millisecond
 		}
-		delay := baseDelay * time.Duration(1<<uint(delivery.AttemptCount-1))
+
+		shift := delivery.AttemptCount - 1
+		if shift > 30 {
+			shift = 30 // Cap shift to prevent integer overflow
+		}
+
+		delay := baseDelay * time.Duration(1<<uint(shift))
 		maxDelay := 1 * time.Hour
 		if delay > maxDelay {
 			delay = maxDelay


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Integer overflow in exponential backoff delay calculation caused by unconstrained left bitwise shift (`1<<uint(AttemptCount-1)`).
🎯 Impact: Once `AttemptCount` is large enough to shift bits out of bounds, the shift resolves to 0. This causes the timeout delay to become 0 instantly, turning exponential backoff into infinite immediate retries and leading to potential Denial of Service (DoS).
🔧 Fix: Add an explicit cap (30) to the shift exponent to prevent integer overflow while still correctly reaching the 1-hour maximum delay.
✅ Verification: `gosec` scan passes and integer overflow vulnerability is mitigated. Tests completed with expected results. Critical learnings logged to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8454979339820602871](https://jules.google.com/task/8454979339820602871) started by @Rfluid*