### PR TITLE
Update safe dynamic sql columns skill pattern

### DIFF
--- a/.agent/skills/safe-dynamic-sql-columns/SKILL.md
+++ b/.agent/skills/safe-dynamic-sql-columns/SKILL.md
@@ -12,15 +12,15 @@ While parameterized queries (`?` in GORM) protect against SQL injection in colum
 
 ## Preferred Pattern
 
-Always validate dynamic column keys against an explicit whitelist or use strongly-typed models (like `SearchableColumn`) before interpolating them into SQL strings.
+Use a `switch` statement to map user input to hardcoded string literals for database identifiers. Avoid `fmt.Sprintf` for identifiers even if the input is validated via an `IsValid()` method.
 
 ## Workflow
 
 1. Identify areas where column names for queries (like order by, filters, or select fields) are determined at runtime.
-2. Define an explicit whitelist of allowed column names as a slice or map, or use a strongly-typed enum/struct (e.g., `SearchableColumn` if the project uses that pattern).
-3. Before executing the query, validate that the provided column name exists in the whitelist.
-4. Return an appropriate error (e.g., `400 Bad Request` or an invalid input error) if the requested column is not allowed.
-5. Once validated, it is safe to use `fmt.Sprintf` or string concatenation to build the query containing the column name.
+2. Replace any string interpolation (`fmt.Sprintf`) of column names with a `switch` statement.
+3. Inside the `switch`, map the valid user input strings directly to hardcoded SQL identifier strings.
+4. Add a `default` case to return an appropriate error (e.g., `400 Bad Request` or an invalid input error) if the requested column is not allowed.
+5. Use the mapped hardcoded string literal in the query builder.
 
 ## Inspect First
 
@@ -30,8 +30,9 @@ Always validate dynamic column keys against an explicit whitelist or use strongl
 
 ## Anti-Patterns
 
-- Directly interpolating user-provided strings into GORM's `.Where()`, `.Select()`, `.Order()`, or `.Group()` without validation.
-- Relying solely on URL decoding or basic sanitization (like removing quotes) instead of explicit whitelisting.
+- Directly interpolating user-provided strings into GORM's `.Where()`, `.Select()`, `.Order()`, or `.Group()`.
+- Using `fmt.Sprintf` or string concatenation for column/table identifiers, even after validating the input against a whitelist or `IsValid()` method.
+- Relying solely on URL decoding or basic sanitization (like removing quotes) instead of explicit mapping.
 
 ## Done Criteria
 


### PR DESCRIPTION
- **What**: Updated the "Preferred Pattern", "Workflow", and "Anti-Patterns" sections in `.agent/skills/safe-dynamic-sql-columns/SKILL.md`.
- **Why**: The previous pattern allowed `fmt.Sprintf` interpolation after whitelist validation, which is less secure and prone to bypasses or errors compared to explicit mapping. Memory explicitly noted this drift and required the `switch` statement pattern.
- **Result**: Future agent operations will now correctly implement `switch` statements for mapping dynamic SQL column names instead of relying on string interpolation, improving security.

---
*PR created automatically by Jules for task [17931833711190876711](https://jules.google.com/task/17931833711190876711) started by @Rfluid*