### PR TITLE
🛡️ Sentinel: [HIGH] Fix integer overflow in exponential backoff

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-26 - Integer Overflow in Exponential Backoff Bitwise Shift
+**Vulnerability:** Potential CWE-190 Integer Overflow in webhook backoff calculations where shifting `1 << uint(delivery.AttemptCount - 1)` can overflow Go's native integer types if `AttemptCount` is extremely large or if underflow occurs (e.g. `AttemptCount` == 0 causing negative numbers to become large unsigned ints).
+**Learning:** Bitwise shift operators in Go (`<<`) can overflow silently when processing unconstrained database integer columns (like attempt counts). If the shifted bit exceeds int sizes (31 or 63), it wraps to zero, rendering the wait time logic null.
+**Prevention:** When implementing exponential backoff or dynamic math using bitwise shifts, explicitly cap the shift limit (e.g., `if shift > 30 { shift = 30 }`) before performing the shift to prevent integer overflows.

--- a/src/webhook/service/queue.go
+++ b/src/webhook/service/queue.go
@@ -181,7 +181,16 @@ func UpdateDeliveryStatus(delivery *webhook_entity.WebhookDelivery, success bool
 		if baseDelay == 0 {
 			baseDelay = 1000 * time.Millisecond
 		}
-		delay := baseDelay * time.Duration(1<<uint(delivery.AttemptCount-1))
+
+		shift := delivery.AttemptCount - 1
+		if shift < 0 {
+			shift = 0
+		}
+		if shift > 30 {
+			shift = 30 // Prevent integer overflow. 2^30 is more than enough since delay is capped at 1h.
+		}
+
+		delay := baseDelay * time.Duration(1<<uint(shift))
 		maxDelay := 1 * time.Hour
 		if delay > maxDelay {
 			delay = maxDelay


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Potential CWE-190 Integer Overflow in webhook backoff calculations where shifting `1 << uint(delivery.AttemptCount - 1)` can overflow Go's native integer types if `AttemptCount` is extremely large, or if it underflows (e.g. `AttemptCount == 0`).
🎯 Impact: An integer overflow silently evaluates the shifted value to 0. This sets the backoff delay to 0, which bypasses the exponential backoff mechanism entirely, potentially causing a retry storm and Denial of Service (DoS) against downstream systems or the local database.
🔧 Fix: Explicitly calculated the shift value, prevented negative underflows, and capped the maximum shift value to 30 to guarantee it never exceeds standard integer bounds while easily hitting the 1-hour maxDelay cap.
✅ Verification: Ran `gosec` to verify G115 (CWE-190) is cleared, and ran unit tests to ensure no regressions were introduced.

---
*PR created automatically by Jules for task [6098488254426824375](https://jules.google.com/task/6098488254426824375) started by @Rfluid*