### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Integer Overflow in Webhook Backoff Calculation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-27 - Integer Overflow in Dynamic Backoff Calculations
+**Vulnerability:** An integer overflow `int -> uint` vulnerability leading to an unconstrained bitwise shift (`1 << uint(attemptCount)`) was discovered in webhook delivery backoff retry delay calculations.
+**Learning:** `attemptCount` increments can grow unboundedly during retry loops. Directly using user/database-controlled unconstrained numbers in bitwise shift operations (`<<`) will lead to integer overflow/underflow, runtime panics, or zero evaluations if the value exceeds bit bounds (e.g. `31` or `63`).
+**Prevention:** Always cap variables used in dynamic bitwise shift calculations (e.g., `if shift > 30 { shift = 30 }`) and sanitize for underflows (`if shift < 0 { shift = 0 }`) before applying them to a shift operator.

--- a/src/webhook/service/queue.go
+++ b/src/webhook/service/queue.go
@@ -181,7 +181,16 @@ func UpdateDeliveryStatus(delivery *webhook_entity.WebhookDelivery, success bool
 		if baseDelay == 0 {
 			baseDelay = 1000 * time.Millisecond
 		}
-		delay := baseDelay * time.Duration(1<<uint(delivery.AttemptCount-1))
+
+		shift := delivery.AttemptCount - 1
+		if shift < 0 {
+			shift = 0
+		}
+		if shift > 30 {
+			shift = 30 // Cap to prevent integer overflow
+		}
+
+		delay := baseDelay * time.Duration(1<<shift)
 		maxDelay := 1 * time.Hour
 		if delay > maxDelay {
 			delay = maxDelay


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Integer overflow `int -> uint` leading to an unconstrained bitwise shift (`1 << uint(attemptCount)`) in webhook delivery backoff retry delay calculations. This could cause runtime panics or incorrect zero evaluations when unbounded inputs exceed 31 bits.
🎯 Impact: Denial of Service (DoS) via runtime panic or infinitely looping backoff delays on failure when the integer exceeds bit limits.
🔧 Fix: Capped the bitwise shift limit to a maximum of 30 and prevented underflows.
✅ Verification: `go build ./...` succeeds and manual testing of math confirms bounded shift.

---
*PR created automatically by Jules for task [18086049856886586492](https://jules.google.com/task/18086049856886586492) started by @Rfluid*