### PR TITLE
docs: update multi-tenant README with missing workspace invitation endpoints

### DIFF
--- a/docs/features/multi_tenant/README.md
+++ b/docs/features/multi_tenant/README.md
@@ -1047,6 +1047,8 @@ Note: Messages inherit workspace scope through messaging_product_id → workspac
 | PATCH  | `/workspace/:id/member/:uid`       | Update member           | Admin  |
 | DELETE | `/workspace/:id/member/:uid`       | Remove member           | Admin  |
 | POST   | `/workspace/:id/invitation`        | Send invitation         | Admin  |
+| GET    | `/workspace/:id/invitation`        | List invitations        | Admin  |
+| DELETE | `/workspace/:id/invitation/:iid`   | Revoke invitation       | Admin  |
 | POST   | `/workspace/:id/phone-config`      | Create phone config     | Admin  |
 | GET    | `/workspace/:id/phone-config`      | List phone configs      | Member |
 | PATCH  | `/workspace/:id/phone-config/:pid` | Update phone config     | Admin  |


### PR DESCRIPTION
## 🎯 What
Adds missing workspace invitation endpoints (`GET` and `DELETE`) to the `docs/features/multi_tenant/README.md` New Endpoints API table.

## 💡 Why
The `GET` and `DELETE` endpoints for managing workspace invitations were implemented in the routing and handler logic (via `src/workspace/router/main.go` and `src/workspace/handler/invitation.go`) but the API summary table in the multi-tenant feature documentation only mentioned the `POST` creation endpoint. This PR corrects the omission.

## ✅ Verification
- Read the updated Markdown file to verify exact table alignment and correctness.
- Executed `go test ./... -p 1 -short` to ensure standard tests weren't negatively affected (no regressions).
- Passed automated AI code review.

---
*PR created automatically by Jules for task [5115447995974196628](https://jules.google.com/task/5115447995974196628) started by @Rfluid*