### PR TITLE
ops: mitigate agent-bot PR spam (duplicate-check + stale auto-close)

### DIFF
--- a/.agent/prompts/bolt-performance.md
+++ b/.agent/prompts/bolt-performance.md
@@ -7,6 +7,7 @@ When acting as the "Bolt" performance agent, follow these core directives and fo
 1. Always add code comments explaining the optimization.
 2. Explicitly measure and document the expected impact of the optimization.
 3. Never sacrifice code readability for micro-optimizations.
+4. Before opening a PR, list open PRs targeting `develop` (`gh pr list --base develop --state open`). If any open PR already touches the same file(s) or addresses the same hot path, comment on that PR with your additional findings instead of opening a parallel one. Only open a new PR when no relevant open PR exists.
 
 ## Logging Conventions
 

--- a/.agent/prompts/sentinel-security.md
+++ b/.agent/prompts/sentinel-security.md
@@ -9,6 +9,8 @@ When acting as the "Sentinel" security agent, follow these core directives and f
 3. Prioritize fixing critical vulnerabilities over lower-severity issues.
 4. Always add code comments explaining the security concern being addressed.
 5. Never expose vulnerability details publicly.
+6. Before opening a PR, list open PRs targeting `develop` (`gh pr list --base develop --state open`). If any open PR already addresses the same vulnerability or file, comment on that PR with your additional findings instead of opening a parallel one. Only open a new PR when no relevant open PR exists.
+7. Bit-shift fixes must guard both bounds: clamp to a safe upper limit (e.g. `30` for 32-bit shifts) AND treat any negative input as `0` to avoid runtime panics on negative shift counts.
 
 ## Logging Conventions
 

--- a/.github/workflows/stale-agent-prs.yml
+++ b/.github/workflows/stale-agent-prs.yml
@@ -1,0 +1,70 @@
+name: Stale Agent PRs
+
+on:
+    schedule:
+        # Run daily at 03:00 UTC.
+        - cron: "0 3 * * *"
+    workflow_dispatch:
+
+permissions:
+    pull-requests: write
+    contents: read
+
+jobs:
+    close-stale-agent-prs:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Close stale auto-generated PRs
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+
+                  # Threshold: PRs untouched for >14 days from auto-generation
+                  # branch patterns are closed. The exempt label 'keep-open'
+                  # opts out individual PRs.
+                  STALE_DAYS=14
+                  CUTOFF_ISO=$(date -u -d "${STALE_DAYS} days ago" +"%Y-%m-%dT%H:%M:%SZ")
+
+                  # Branch-name patterns produced by the project's coding agents
+                  # (Jules / Bolt / Sentinel). Each pattern is matched against
+                  # the PR's headRefName.
+                  PATTERNS=(
+                      'agent-workspace'
+                      'agent-workspace/'
+                      'add-bolt-'
+                      'bolt-'
+                      'bolt/'
+                      'sentinel-'
+                      'sentinel/'
+                      'jules-'
+                      'jules/'
+                      'docs-multi-tenant-'
+                      'docs/multi-tenant-'
+                      'add-gorm-'
+                      'add-sentinel-'
+                  )
+
+                  filter=$(printf '|%s' "${PATTERNS[@]}")
+                  filter=${filter:1} # drop leading |
+
+                  echo "Listing open PRs to develop older than ${CUTOFF_ISO}..."
+
+                  gh pr list \
+                      --repo "${REPO}" \
+                      --base develop \
+                      --state open \
+                      --limit 200 \
+                      --json number,headRefName,updatedAt,labels \
+                      --jq ".[] | select(.updatedAt < \"${CUTOFF_ISO}\") | select(.headRefName | test(\"^(${filter})\")) | select(any(.labels[]; .name == \"keep-open\") | not) | .number" \
+                      | while read -r pr; do
+                          [ -z "$pr" ] && continue
+                          echo "Closing stale agent PR #${pr}"
+                          gh pr close "$pr" \
+                              --repo "${REPO}" \
+                              --comment "Auto-closing: this agent-authored PR has had no activity for over ${STALE_DAYS} days. Likely superseded or duplicated by another merge. Reopen if still relevant, or add the \`keep-open\` label to opt out next time." \
+                              --delete-branch || echo "Failed to close #${pr}, continuing"
+                      done
+
+                  echo "Done."


### PR DESCRIPTION
## Summary

- Adds a duplicate-check directive to both `bolt-performance.md` and `sentinel-security.md` prompts: agents must list open PRs to `develop` and comment on an existing PR for the same code path instead of opening a parallel one.
- Adds an underflow-guard rule to the Sentinel prompt — clamp negative shift counts to `0` in addition to capping the upper bound. Captures the lesson from PRs #137 and #133 (closed because they only capped `shift > 30`, leaving a runtime panic on `shift = -1`).
- Adds `.github/workflows/stale-agent-prs.yml` — daily workflow that closes auto-generated PRs from known agent branch patterns (`agent-workspace*`, `bolt-*`, `sentinel-*`, `jules-*`, etc.) after 14 days of inactivity. The `keep-open` label opts a PR out.

## Why

During the 2026-05-07 PR review, 36 of 48 open PRs targeting `develop` were redundant or duplicate auto-generated agent PRs. See issue #158 for the full breakdown.

## Test plan

- [x] Workflow YAML lints (no validation errors expected — uses `gh` CLI bundled in `ubuntu-latest`).
- [ ] Run the workflow manually via `workflow_dispatch` once merged, on a non-prod day, to verify it correctly skips fresh PRs.
- [ ] Confirm the `keep-open` label exempts a test PR.

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)