### PR TITLE
feat(agent): add postgres-robust-search skill

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -32,4 +32,5 @@ Current examples:
 
 - `skills/go-update-endpoint/SKILL.md` - workflow for safe GORM update handlers that must preserve zero values
 - `skills/add-module-slice/SKILL.md` - workflow for adding a new `handler/router/service` feature slice
+- `skills/postgres-robust-search/SKILL.md` - workflow for safe and consistent case/accent-insensitive Postgres text searches
 - `tools/inspect-server-surface.sh` - quick trace for server boot, routing, config, sync, and worker entry points

--- a/.agent/skills/postgres-robust-search/SKILL.md
+++ b/.agent/skills/postgres-robust-search/SKILL.md
@@ -1,0 +1,43 @@
+# Skill: Postgres Robust Search
+
+Use this skill when implementing search or filter endpoints that query text columns in PostgreSQL, especially via GORM.
+
+## Purpose
+
+Ensure text searches are robust, case-insensitive, accent-insensitive, and immune to NULL pointer issues when filtering database records.
+
+## Core Problem
+
+Directly using `ILIKE ?` on text columns can lead to:
+- Accent sensitivity (e.g., searching for "cafe" won't match "café").
+- Null constraint issues if the column value is NULL, which might evaluate in unexpected ways compared to an empty string.
+
+## Preferred Pattern
+
+Always use the established pattern: `immutable_unaccent(COALESCE(column::text, '')) ILIKE immutable_unaccent(?)`
+
+## Workflow
+
+1. Identify text columns that need to be searchable or filterable.
+2. In your GORM queries (`.Where(...)`), instead of `column ILIKE ?`, use the pattern:
+   `immutable_unaccent(COALESCE(column_name::text, '')) ILIKE immutable_unaccent(?)`
+3. Ensure you format the `?` value appropriately for ILIKE matches (e.g., `"%"+searchTerm+"%"`).
+
+## Inspect First
+
+- Search queries in `src/<domain>/service/like.go` or `src/<domain>/service/count.go` (e.g., `message/service/like.go`, `campaign/service/like.go`).
+- Notice how `fmt.Sprintf` is used carefully (only for mapping valid, normalized keys, never user input directly) to construct the query string safely.
+
+## Anti-Patterns
+
+- Using basic `ILIKE ?` without handling accents.
+- Failing to use `COALESCE`, potentially missing rows where the column is NULL.
+- Applying `immutable_unaccent` to one side of the query but not the other.
+- Concatenating user input directly into the query string instead of using parameterized queries `?` for the search term.
+
+## Done Criteria
+
+- Searches handle case insensitivity.
+- Searches handle accent insensitivity.
+- Null values do not break the query or exclude results incorrectly.
+- The `immutable_unaccent` function is applied consistently.


### PR DESCRIPTION
This PR introduces a new `.agent/skills/postgres-robust-search/SKILL.md` to document the correct handling of text-based searches in PostgreSQL via GORM to ensure robustness. The pattern documented (`immutable_unaccent(COALESCE(column::text, '')) ILIKE immutable_unaccent(?)`) is critical for case and accent-insensitive queries and handling null values, reducing bugs in the long term. This PR also updates the `.agent/README.md` to index this new skill. This update is localized to the `.agent/` workspace to guide future operations without affecting core source code.

---
*PR created automatically by Jules for task [17076737420783967460](https://jules.google.com/task/17076737420783967460) started by @Rfluid*