### PR TITLE
Update Agent Workspace: Add vulnerability scanning instructions to Sentinel prompt

### DIFF
--- a/.agent/prompts/sentinel-security.md
+++ b/.agent/prompts/sentinel-security.md
@@ -12,6 +12,12 @@ When acting as the "Sentinel" security agent, follow these core directives and f
 6. Before opening a PR, list open PRs targeting `develop` (`gh pr list --base develop --state open`). If any open PR already addresses the same vulnerability or file, comment on that PR with your additional findings instead of opening a parallel one. Only open a new PR when no relevant open PR exists.
 7. Bit-shift fixes must guard both bounds: clamp to a safe upper limit (e.g. `30` for 32-bit shifts) AND treat any negative input as `0` to avoid runtime panics on negative shift counts.
 
+## Vulnerability Scanning
+
+To scan for common security vulnerabilities in the Go codebase, install and run `gosec` via:
+`go install github.com/securego/gosec/v2/cmd/gosec@latest && ~/go/bin/gosec -exclude-dir=tests -exclude-dir=mocks ./...`
+**Crucial Tip:** When scanning specific packages, pass the directory path (e.g., `./src/webhook/service/`) instead of individual file paths to prevent "cannot find package" errors.
+
 ## Logging Conventions
 
 When identifying critical vulnerabilities or applying fixes, log your findings in `.jules/sentinel.md` using the exact format below:


### PR DESCRIPTION
This pull request updates the `.agent/prompts/sentinel-security.md` file to include explicit instructions for using `gosec` for vulnerability scanning.

**Motivation:** Future operations under the "Sentinel" persona need a clear, standardized way to scan the codebase for security vulnerabilities without encountering common Go package errors.

**Modifications:**
- Added a "Vulnerability Scanning" section to `.agent/prompts/sentinel-security.md`.
- Documented the `go install` and `gosec` execution commands.
- Included a crucial tip about passing directory paths instead of specific file paths to avoid "cannot find package" errors.

**Improvement for future agent operations:** This ensures that when the agent is tasked with security reviews or improvements, it has immediate access to the correct scanning command and knows how to avoid common pitfalls, leading to faster and more reliable security patching.

---
*PR created automatically by Jules for task [6043207172832714745](https://jules.google.com/task/6043207172832714745) started by @Rfluid*