### PR TITLE
Add gorm-manual-preload-optimization skill to agent workspace

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -32,4 +32,5 @@ Current examples:
 
 - `skills/go-update-endpoint/SKILL.md` - workflow for safe GORM update handlers that must preserve zero values
 - `skills/add-module-slice/SKILL.md` - workflow for adding a new `handler/router/service` feature slice
+- `skills/gorm-manual-preload-optimization/SKILL.md` - workflow for manual GORM relation assignment to optimize 'get-or-save' operations
 - `tools/inspect-server-surface.sh` - quick trace for server boot, routing, config, sync, and worker entry points

--- a/.agent/skills/gorm-manual-preload-optimization/SKILL.md
+++ b/.agent/skills/gorm-manual-preload-optimization/SKILL.md
@@ -1,0 +1,44 @@
+# Skill: GORM Manual Preload Optimization
+
+Use this skill when implementing 'get-or-save' database operations to eliminate redundant GORM `.Preload()` queries by manually populating relationship fields of created entities using available in-memory data.
+
+## Purpose
+
+To prevent N+1 query performance issues immediately following record creation. When a new entity is inserted via GORM, it does not automatically fetch its relationship data even if the foreign keys are set. Performing a `.Preload()` after insertion incurs an unnecessary database round-trip because the related entity data is often already available in memory within the current scope (e.g., from a prior lookup or from the request context).
+
+## Core Problem
+
+A common but inefficient pattern is to:
+1. Fetch a related entity (e.g., to verify it exists).
+2. Create a new primary entity referencing the related entity's ID.
+3. Reload the primary entity from the database using `.Preload()` just to populate the related struct field before returning it in the API response.
+
+This results in a completely redundant `SELECT` query.
+
+## Preferred Pattern
+
+Manually assign the related entity pointer to the newly created struct before returning.
+
+- Look up the related entity (if not already available).
+- Create the new primary entity using the foreign key.
+- Assign the related entity (or a reference to it) directly to the primary entity's relationship field.
+- Return the populated entity without executing a subsequent `.Preload()`.
+
+## Workflow
+
+1. Identify the 'get-or-save' or creation operation.
+2. Ensure the related entities are available in memory (often fetched earlier in the handler or service for validation).
+3. Insert the new record via `db.Create()`.
+4. Directly assign the in-memory related entity to the newly created object's relationship field (e.g., `newEntity.RelatedEntity = &relatedEntity`).
+5. Return the result, avoiding any `db.Preload().First()` reloading logic.
+
+## Anti-Patterns
+
+- Executing `db.Preload("Relationship").First(&entity, entity.ID)` immediately after `db.Create(&entity)`.
+- Re-querying data that was already validated or fetched higher up in the request context.
+
+## Done Criteria
+
+- The `.Preload()` call following the insert is removed.
+- The returned entity correctly includes the nested relationship data.
+- The number of SQL queries executed during the creation flow is reduced.


### PR DESCRIPTION
1.  **Explanation and Motivation:**
    Added a new workflow instruction to the `.agent/skills/` directory. The `gorm-manual-preload-optimization` skill addresses a common but inefficient pattern when handling "get-or-save" operations with GORM. Often, a redundant `.Preload()` query is executed immediately following `db.Create()` just to populate the created entity's relationship fields, even though that data is usually already in memory from prior validation checks. This skill standardizes the pattern of manually assigning those pointers, avoiding N+1 queries.

2.  **Modifications:**
    -   Added `.agent/skills/gorm-manual-preload-optimization/SKILL.md` documenting the optimization pattern.
    -   Modified `.agent/README.md` to reference the new skill under the "Repo-Specific Assets" section.

3.  **Impact on Future Agent Operations:**
    Agents working on optimizing database interactions or implementing new feature slice handlers will now have a clear, repo-specific pattern for eliminating redundant reload queries. By having this skill documented, future agents can confidently avoid executing `db.Preload().First()` immediately after insertions when the relationship data is already known in the request context.

---
*PR created automatically by Jules for task [5866931482557927220](https://jules.google.com/task/5866931482557927220) started by @Rfluid*